### PR TITLE
doc: initial sync of nodejs/open-standards members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # Node.js Open Standards Team
 
+## Team Members
+
+<!-- ncu-team-sync.team(nodejs/open-standards) -->
+
+- [@addaleax](https://github.com/addaleax) - Anna Henningsen
+- [@apapirovski](https://github.com/apapirovski) - Anatoli Papirovski
+- [@benjamingr](https://github.com/benjamingr) - Benjamin Gruenbaum
+- [@bmeck](https://github.com/bmeck) - Bradley Meck
+- [@bnb](https://github.com/bnb) - Tierney Cyren
+- [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
+- [@devsnek](https://github.com/devsnek) - Gus Caplan
+- [@dshaw](https://github.com/dshaw) - Dan Shaw
+- [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
+- [@jasnell](https://github.com/jasnell) - James M Snell
+- [@joyeecheung](https://github.com/joyeecheung) - Joyee Cheung
+- [@ljharb](https://github.com/ljharb) - Jordan Harband
+- [@mcollina](https://github.com/mcollina) - Matteo Collina
+- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
+- [@rubys](https://github.com/rubys) - Sam Ruby
+- [@TimothyGu](https://github.com/TimothyGu) - Timothy Gu
+
+<!-- ncu-team-sync end -->


### PR DESCRIPTION
Refs: https://github.com/nodejs/admin/issues/213
Refs: https://github.com/nodejs/TSC/issues/583

I've sent invitations to people nominated/indicated that they are willing to help in https://github.com/nodejs/TSC/issues/583 to join the team @nodejs/open-standards 

Three members pending the acceptance of the invitation because they are not yet members of this organization: @ladyleet @littledan @kenchris

cc @MylesBorins ( who is on vacation, but I feel that I should still cc you..sorry ;) )